### PR TITLE
changed file references in pytest

### DIFF
--- a/assignment_1_1/test/test1.py
+++ b/assignment_1_1/test/test1.py
@@ -1,16 +1,18 @@
-# import pytest
-import pytest
 import json
+import os
 import sys
+
 import numpy as np
-sys.path.append('../')
-sys.path.append('../src')
-from src.geometry import *
-from src.shear import *
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from geometry import *
+from shear import *
 
 eps = 1E-6
 
-with open('test_data1.json', 'r') as infile:
+with open(os.path.join(os.path.dirname(__file__), "test_data1.json"), "r") as infile:
     homework_datas = json.load(infile)
 
 @pytest.mark.timeout(1)


### PR DESCRIPTION
This makes it possible to run the tests from any working directory, so you can run either `pytest test/test1.py` or `cd test && pytest test1.py`.

For future homeworks, I also suggest naming the file `test_1.py` instead of `test1.py`.
The format with underscores allows pytest to discover all tests in a directory (`pytest test/`), including tests added by students.